### PR TITLE
Added support for the power down mode of the W25Q32JV

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Defmt is also supported through the `defmt` feature.
 
 ## Changelog
 
+### [x.x.x] 
+
+- Added functions to use the power down mode of the W25Q32JV.
+
 ### [0.3.1] - 2023-10-24
 
 - Added readback-check feature that reads back the writes and the erases to check if they've succeeded ok

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,8 @@ enum Command {
     Block64Erase = 0xD8,
     ChipErase = 0xC7,
     EnableReset = 0x66,
+    PowerDown = 0xB9,
+    ReleasePowerDown = 0xAB,
     Reset = 0x99,
 }
 

--- a/src/w25q32jv.rs
+++ b/src/w25q32jv.rs
@@ -353,8 +353,8 @@ where
         Ok(())
     }
 
-    /// Puts the chip into power down mode
-    /// While in the power-down state only the Release Power-down/Device ID (ABh) instruction, which restores the device to normal operation, will be recognized. All other instructions are ignored
+    /// Puts the chip into power down mode.
+    /// While in the power-down state, only the Release Power-down/Device ID (0xAB) instruction will be recognized. This instruction restores the device to normal operation. All other instructions are ignored.
     pub fn enable_power_down_mode(&mut self) -> Result<(), Error<S, P>> {
         self.spi
             .write(&[Command::PowerDown as u8])
@@ -363,8 +363,8 @@ where
         Ok(())
     }
 
-    /// Releases power down mode  
-    /// Restores operation from power down mode by reading the deviceID from the device
+    /// Releases the chip from power down mode.
+    /// Restores operation from power down mode by reading the deviceID from the device.
     pub fn disable_power_down_mode(&mut self) -> Result<(), Error<S, P>> {
         self.spi
             .write(&[Command::ReleasePowerDown as u8])

--- a/src/w25q32jv.rs
+++ b/src/w25q32jv.rs
@@ -352,4 +352,24 @@ where
 
         Ok(())
     }
+
+    /// Puts the chip into power down mode
+    /// While in the power-down state only the Release Power-down/Device ID (ABh) instruction, which restores the device to normal operation, will be recognized. All other instructions are ignored
+    pub fn enable_power_down_mode(&mut self) -> Result<(), Error<S, P>> {
+        self.spi
+            .write(&[Command::PowerDown as u8])
+            .map_err(Error::SpiError)?;
+
+        Ok(())
+    }
+
+    /// Releases power down mode  
+    /// Restores operation from power down mode by reading the deviceID from the device
+    pub fn disable_power_down_mode(&mut self) -> Result<(), Error<S, P>> {
+        self.spi
+            .write(&[Command::ReleasePowerDown as u8])
+            .map_err(Error::SpiError)?;
+
+        Ok(())
+    }
 }

--- a/src/w25q32jv_async.rs
+++ b/src/w25q32jv_async.rs
@@ -369,8 +369,8 @@ where
         Ok(())
     }
 
-    /// Puts the chip into power down mode
-    /// While in the power-down state only the Release Power-down/Device ID (ABh) instruction, which restores the device to normal operation, will be recognized. All other instructions are ignored
+    /// Puts the chip into power down mode.
+    /// While in the power-down state, only the Release Power-down/Device ID (0xAB) instruction will be recognized. This instruction restores the device to normal operation. All other instructions are ignored.
     pub async fn enable_power_down_mode_async(&mut self) -> Result<(), Error<S, P>> {
         self.spi
             .write(&[Command::PowerDown as u8])
@@ -380,8 +380,8 @@ where
         Ok(())
     }
 
-    /// Releases power down mode  
-    /// Restores operation from power down mode by reading the deviceID from the device
+    /// Releases the chip from power down mode.
+    /// Restores operation from power down mode by reading the deviceID from the device.
     pub async fn disable_power_down_mode_async(&mut self) -> Result<(), Error<S, P>> {
         self.spi
             .write(&[Command::ReleasePowerDown as u8])

--- a/src/w25q32jv_async.rs
+++ b/src/w25q32jv_async.rs
@@ -368,4 +368,26 @@ where
 
         Ok(())
     }
+
+    /// Puts the chip into power down mode
+    /// While in the power-down state only the Release Power-down/Device ID (ABh) instruction, which restores the device to normal operation, will be recognized. All other instructions are ignored
+    pub async fn enable_power_down_mode_async(&mut self) -> Result<(), Error<S, P>> {
+        self.spi
+            .write(&[Command::PowerDown as u8])
+            .await
+            .map_err(Error::SpiError)?;
+
+        Ok(())
+    }
+
+    /// Releases power down mode  
+    /// Restores operation from power down mode by reading the deviceID from the device
+    pub async fn disable_power_down_mode_async(&mut self) -> Result<(), Error<S, P>> {
+        self.spi
+            .write(&[Command::ReleasePowerDown as u8])
+            .await
+            .map_err(Error::SpiError)?;
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Added functions to enable and disable the power down mode of the chip.

See page 44 and 45 of the [datasheet](https://nl.mouser.com/datasheet/2/949/w25q32jv_revg_03272018_plus-1489806.pdf#page=44) for the description of the Power-down and Release Power-down instructions. 