### PR TITLE
Add marker trait for Multiwrite to ASYNC API.

### DIFF
--- a/src/w25q32jv_async.rs
+++ b/src/w25q32jv_async.rs
@@ -2,7 +2,7 @@ use super::*;
 use core::fmt::Debug;
 use embedded_hal::digital::OutputPin;
 use embedded_hal_async::spi::{Operation, SpiDevice};
-use embedded_storage_async::nor_flash::{NorFlash, ReadNorFlash};
+use embedded_storage_async::nor_flash::{MultiwriteNorFlash, NorFlash, ReadNorFlash};
 
 impl<SPI, S: Debug, P: Debug, HOLD, WP> ReadNorFlash for W25q32jv<SPI, HOLD, WP>
 where
@@ -42,6 +42,16 @@ where
     async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
         self.write_async(offset, bytes).await
     }
+}
+
+impl<SPI, S: Debug, P: Debug, HOLD, WP> MultiwriteNorFlash for W25q32jv<SPI, HOLD, WP>
+where
+    SPI: SpiDevice<Error = S>,
+    HOLD: OutputPin<Error = P>,
+    WP: OutputPin<Error = P>,
+    S: Debug,
+    P: Debug,
+{
 }
 
 impl<SPI, S: Debug, P: Debug, HOLD, WP> W25q32jv<SPI, HOLD, WP>


### PR DESCRIPTION
Hi @diondokter, I was trying to use sequential-storage with this driver (embassy-stm32 + RTIC on STM32G431). Using code stolen from the example, compile failed unless I commented out the second hald of 'run_queue' due to pop requiring the MultiwriteNorFlash trait.

I note that this driver implements this trait for embedded_storage but nor for embedded_storage_async. If I implement this trait (as per this pull request), everything compiles and at least the simple example appears to work.

I did a side-by-side comparison of w25q32jv.rs and w25q32jv_async.rs and I could not find anything different between the two apart from the boilerplate differences between async and not-async so on the surface it seems like if it is safe for the non-async to have this trait, so should the async?

As such, this pull request simply implements the embedded_storage_async::nor_flash::MultiwriteNorFlash trait for W25q32jv.