### PR TITLE
Add a feature flag to support 128M-bit variants.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ default = ["readback-check", "async"]
 async = ["dep:embedded-hal-async", "dep:embedded-storage-async"]
 defmt = ["dep:defmt"]
 readback-check = []
+megabits128 = []
 
 [dev-dependencies]
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/w25q32jv.svg)](https://crates.io/crates/w25q32jv) [![Documentation](https://docs.rs/w25q32jv/badge.svg)](https://docs.rs/w25q32jv)
 
-This is a generic driver for the W25Q32JV flash chip from Winbond.
+This is a generic driver for the W25Q32JV and W25Q128FV flash chip from Winbond. It probably also works with other similar variants.
 
 It supports:
 - Blocking SPI using `embedded-hal 1.0`
@@ -11,6 +11,7 @@ It supports:
 - Async `embedded-storage-async`
 
 To unlock the use of async, activate the `async` feature on the crate.
+Default is W25Q32(32 M-bit), activate `+megabits128` to support W25Q128(128 M-bit).
 
 Defmt is also supported through the `defmt` feature.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,13 @@ mod w25q32jv;
 mod w25q32jv_async;
 
 pub const PAGE_SIZE: u32 = 256;
+
+#[cfg(not(feature = "megabits128"))]
 pub const N_PAGES: u32 = 16384;
+
+#[cfg(feature = "megabits128")]
+pub const N_PAGES: u32 = 65536;
+
 pub const CAPACITY: u32 = PAGE_SIZE * N_PAGES;
 
 pub const SECTOR_SIZE: u32 = PAGE_SIZE * 16;


### PR DESCRIPTION
W25Q128 Chip is the same with just more pages. Adding a feature flag seems a simple way to allow use of the rest of the chip. This is simpler than adding a generic argument.