### PR TITLE
Add support for W25Q64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ embedded-storage = "0.3.0"
 embedded-hal-async = { version = "1.0.0", optional = true }
 embedded-storage-async = { version = "0.4.0", optional = true }
 defmt = { version = "0.3", optional = true }
+cfg-if = "1.0.0"
 
 [features]
 default = ["readback-check", "async"]
@@ -27,6 +28,7 @@ async = ["dep:embedded-hal-async", "dep:embedded-storage-async"]
 defmt = ["dep:defmt"]
 readback-check = []
 megabits128 = []
+megabits64 = []
 
 [dev-dependencies]
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It supports:
 - Async `embedded-storage-async`
 
 To unlock the use of async, activate the `async` feature on the crate.
-Default is W25Q32(32 M-bit), activate `+megabits128` to support W25Q128(128 M-bit).
+Default is W25Q32(32 M-bit), activate `+megabits64` to support W25Q64(64 M-bit), or `+megabits128` to support W25Q128(128 M-bit).
 
 Defmt is also supported through the `defmt` feature.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,15 @@ mod w25q32jv_async;
 
 pub const PAGE_SIZE: u32 = 256;
 
-#[cfg(not(feature = "megabits128"))]
-pub const N_PAGES: u32 = 16384;
-
-#[cfg(feature = "megabits128")]
-pub const N_PAGES: u32 = 65536;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "megabits128")] {
+        pub const N_PAGES: u32 = 65536;
+    } else if #[cfg(feature = "megabits64")] {
+        pub const N_PAGES: u32 = 32768;
+    } else {
+        pub const N_PAGES: u32 = 16384;
+    }
+}
 
 pub const CAPACITY: u32 = PAGE_SIZE * N_PAGES;
 


### PR DESCRIPTION
Since this crate already has support for both W25Q32 and W25Q128, I thought why not complete the set with W25Q64. Also uses a feature flag, but refactored to use cfg-if.